### PR TITLE
Fix message example in Push policy docs

### DIFF
--- a/docs/concepts/policy/git-push-policy.md
+++ b/docs/concepts/policy/git-push-policy.md
@@ -133,7 +133,7 @@ The following Push policy does not trigger any run within Spacelift. Using this 
 
 ```opa
 fail { true }
-message["I love bacon"] ( true )
+message["I love bacon"] { true }
 ```
 
 As a result of the above policy, users would then see this behavior within their GitHub status check:


### PR DESCRIPTION
# Description of the change

It looks like the `message` example in the Git Push policy is incorrectly using parenthesis instead of curly brackets.

```opa
message["I love bacon"] ( true )
```

This results in the following error:

```none
error occurred: policy.rego:4: rego_parse_error: boolean cannot be used for rule name
```

Replacing `( true )` with `{ true }` makes the expression a valid rule.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

Thank you for your contribution! 🙇
